### PR TITLE
fixes config reader encoding

### DIFF
--- a/styletts2_inference/models.py
+++ b/styletts2_inference/models.py
@@ -486,7 +486,7 @@ class StyleTTS2(nn.Module):
             weights_path = hf_hub_download(repo_id=hf_path, filename="pytorch_model.bin")
             config_path = hf_hub_download(repo_id=hf_path, filename="config.yml")
 
-        self.config = recursive_munch(yaml.safe_load(open(config_path)))
+        self.config = recursive_munch(yaml.safe_load(open(config_path, encoding='utf-8')))
         self.tokenizer = StyleTTS2Tokenizer(vocab=self.config.model_params.vocab)
         self.weights = torch.load(weights_path, map_location='cpu', weights_only=True)
         if 'net' in self.weights:


### PR DESCRIPTION
fixes
```python
encoder_model.onnx: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1.63G/1.63G [00:17<00:00, 92.8MB/s]
decoder_model.onnx: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 500k/500k [00:00<00:00, 35.7MB/s]
decoder_model.onnx_data: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2.86G/2.86G [00:50<00:00, 57.0MB/s]
Loading tokenizer...
Creating ONNX sessions...
Traceback (most recent call last):
  File "V:\projects\styletts2-ukrainian-openai-tts-api\styletts2-ukrainian\app.py", line 36, in <module>
    single_model = StyleTTS2(hf_path='patriotyk/styletts2_ukrainian_single', device=device)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "V:\projects\styletts2-ukrainian-openai-tts-api\.venv\Lib\site-packages\styletts2_inference\models.py", line 489, in __init__
    self.config = recursive_munch(yaml.safe_load(open(config_path)))
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "V:\projects\styletts2-ukrainian-openai-tts-api\.venv\Lib\site-packages\yaml\__init__.py", line 125, in safe_load
    return load(stream, SafeLoader)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "V:\projects\styletts2-ukrainian-openai-tts-api\.venv\Lib\site-packages\yaml\__init__.py", line 79, in load
    loader = Loader(stream)
             ^^^^^^^^^^^^^^
  File "V:\projects\styletts2-ukrainian-openai-tts-api\.venv\Lib\site-packages\yaml\loader.py", line 34, in __init__
    Reader.__init__(self, stream)
  File "V:\projects\styletts2-ukrainian-openai-tts-api\.venv\Lib\site-packages\yaml\reader.py", line 85, in __init__
    self.determine_encoding()
  File "V:\projects\styletts2-ukrainian-openai-tts-api\.venv\Lib\site-packages\yaml\reader.py", line 124, in determine_encoding
    self.update_raw()
  File "V:\projects\styletts2-ukrainian-openai-tts-api\.venv\Lib\site-packages\yaml\reader.py", line 178, in update_raw
    data = self.stream.read(size)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\alexe\AppData\Roaming\uv\python\cpython-3.12.9-windows-x86_64-none\Lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 267: character maps to <undefined>

```